### PR TITLE
Replaced console.debug with console.log so that node < v8 can run this module 

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -54,7 +54,7 @@
       this.proxy = new Proxy(proxy, this.logger);
       this.proxy.on('ready', (function(_this) {
         return function() {
-          return _this.logger.debug("proxy connected");
+          return _this.logger.log("proxy connected");
         };
       })(this));
       this.proxy.on('error', (function(_this) {
@@ -99,7 +99,7 @@
       client.once('ready', (function(_this) {
         return function() {
           _this.clients[serverOptions.name] = client;
-          _this.logger.debug(serverOptions.name + " connected");
+          _this.logger.log(serverOptions.name + " connected");
           _this.ready();
           return typeof callback === "function" ? callback() : void 0;
         };


### PR DESCRIPTION
console.debug() is an alias for console.log() and its was only added in node v8.0.0